### PR TITLE
Use provided type resolver

### DIFF
--- a/sourcerer-core/src/main/java/org/elder/sourcerer/DefaultAggregateRepository.java
+++ b/sourcerer-core/src/main/java/org/elder/sourcerer/DefaultAggregateRepository.java
@@ -84,7 +84,7 @@ public class DefaultAggregateRepository<TState, TEvent>
         this(
                 eventRepository,
                 projection,
-                DefaultAggregateRepository::defaultResolveType,
+                typeResolver,
                 DEFAULT_MAX_EVENTS_PER_READ);
     }
 


### PR DESCRIPTION
Fix issue where we accidentally use the default type resolver instead of the provided one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elder-oss/sourcerer/11)
<!-- Reviewable:end -->
