### PR TITLE
Fix expected version merge

### DIFF
--- a/sourcerer-core/src/main/java/org/elder/sourcerer/ExpectedVersion.java
+++ b/sourcerer-core/src/main/java/org/elder/sourcerer/ExpectedVersion.java
@@ -51,76 +51,11 @@ public final class ExpectedVersion {
             final ExpectedVersion baseVersion,
             final ExpectedVersion newVersion) {
         if (baseVersion != null && newVersion != null) {
-            switch (baseVersion.getType()) {
-                case ANY:
-                    // Any is always compatible with other expected version
-                    return newVersion;
-                case ANY_EXISTING:
-                    switch (newVersion.getType()) {
-                        case ANY:
-                        case ANY_EXISTING:
-                            return ExpectedVersion.anyExisting();
-                        case EXACTLY:
-                            return newVersion;
-                        case NOT_CREATED:
-                            throw new ConflictingExpectedVersionsException(
-                                    "Cannot merge 'any existing' with 'not created'",
-                                    baseVersion, newVersion);
-                        default:
-                            throw new IllegalArgumentException(
-                                    "Unrecognized version type: " + newVersion.getType());
-                    }
-                case EXACTLY:
-                    switch (newVersion.getType()) {
-                        case ANY:
-                        case ANY_EXISTING:
-                        case EXACTLY:
-                            if (baseVersion.getExpectedVersion()
-                                    != newVersion.getExpectedVersion()) {
-                                throw new ConflictingExpectedVersionsException(
-                                        "Cannot merge 'exactly "
-                                                + baseVersion.getExpectedVersion()
-                                                + "' with 'exactly "
-                                                + newVersion.getExpectedVersion()
-                                                + "'",
-                                        baseVersion, newVersion);
-                            }
-                            return baseVersion;
-                        case NOT_CREATED:
-                            throw new ConflictingExpectedVersionsException(
-                                    "Cannot merge 'exactly "
-                                            + baseVersion.getExpectedVersion()
-                                            + "' with 'not created'",
-                                    baseVersion, newVersion);
-                        default:
-                            throw new IllegalArgumentException(
-                                    "Unrecognized version type: " + newVersion.getType());
-                    }
-                case NOT_CREATED:
-                    switch (newVersion.getType()) {
-                        case ANY:
-                        case NOT_CREATED:
-                            break;
-                        case ANY_EXISTING:
-                            throw new ConflictingExpectedVersionsException(
-                                    "Cannot merge 'not created' with 'any existing'",
-                                    baseVersion, newVersion);
-                        case EXACTLY:
-                            throw new ConflictingExpectedVersionsException(
-                                    "Cannot merge 'not created' with 'exactly "
-                                            + newVersion.getExpectedVersion() + "'",
-                                    baseVersion, newVersion);
-                        default:
-                            break;
-                    }
-                    return baseVersion;
-                default:
-                    break; // Throws, see below
+            if (baseVersion.getType().compareTo(newVersion.getType()) > 0) {
+                return mergeOrdered(newVersion, baseVersion);
+            } else {
+                return mergeOrdered(baseVersion, newVersion);
             }
-            throw new RuntimeException(
-                    "Internal error, unexpected version combination merging "
-                            + baseVersion
-                            + " with " + newVersion);
         } else if (baseVersion != null) {
             return baseVersion;
         } else if (newVersion != null) {
@@ -128,6 +63,67 @@ public final class ExpectedVersion {
         } else {
             return ExpectedVersion.any();
         }
+    }
+
+    /**
+     * Assumes the expected versions are given in ordinal order.
+     */
+    private static ExpectedVersion mergeOrdered(
+            final ExpectedVersion baseVersion,
+            final ExpectedVersion newVersion) {
+        switch (baseVersion.getType()) {
+            case ANY:
+                // Any is always compatible with other expected version
+                return newVersion;
+            case ANY_EXISTING:
+                switch (newVersion.getType()) {
+                    case ANY_EXISTING:
+                        return ExpectedVersion.anyExisting();
+                    case EXACTLY:
+                        return newVersion;
+                    case NOT_CREATED:
+                        throw new ConflictingExpectedVersionsException(
+                                "Cannot merge 'any existing' with 'not created'",
+                                baseVersion, newVersion);
+                    default:
+                }
+                break;
+            case EXACTLY:
+                switch (newVersion.getType()) {
+                    case EXACTLY:
+                        if (baseVersion.getExpectedVersion()
+                                != newVersion.getExpectedVersion()) {
+                            throw new ConflictingExpectedVersionsException(
+                                    "Cannot merge 'exactly "
+                                            + baseVersion.getExpectedVersion()
+                                            + "' with 'exactly "
+                                            + newVersion.getExpectedVersion()
+                                            + "'",
+                                    baseVersion, newVersion);
+                        }
+                        return baseVersion;
+                    case NOT_CREATED:
+                        throw new ConflictingExpectedVersionsException(
+                                "Cannot merge 'exactly "
+                                        + baseVersion.getExpectedVersion()
+                                        + "' with 'not created'",
+                                baseVersion, newVersion);
+                    default:
+                }
+                break;
+            case NOT_CREATED:
+                switch (newVersion.getType()) {
+                    case NOT_CREATED:
+                        return baseVersion;
+                    default:
+                }
+                break;
+            default:
+        }
+        throw new RuntimeException(
+                "Internal error, unexpected version combination merging "
+                        + baseVersion
+                        + " with " + newVersion);
     }
 
     @Override

--- a/sourcerer-core/src/test/java/org/elder/sourcerer/ExpectedVersionMergeTest.java
+++ b/sourcerer-core/src/test/java/org/elder/sourcerer/ExpectedVersionMergeTest.java
@@ -1,0 +1,137 @@
+package org.elder.sourcerer;
+
+import org.junit.Test;
+
+import static org.elder.sourcerer.ExpectedVersion.any;
+import static org.elder.sourcerer.ExpectedVersion.anyExisting;
+import static org.elder.sourcerer.ExpectedVersion.exactly;
+import static org.elder.sourcerer.ExpectedVersion.merge;
+import static org.elder.sourcerer.ExpectedVersion.notCreated;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * These tests each assert in both directions, merge first with the second, and the second with
+ * the first.
+ */
+public class ExpectedVersionMergeTest {
+
+    // Any
+
+    @Test
+    public void mergeAnyAndAny() {
+        assertMerge(any(), any(), any());
+    }
+
+    @Test
+    public void mergeAnyAndNull() {
+        assertMerge(any(), null, any());
+    }
+
+    @Test
+    public void mergeAnyAndAnyExisting() {
+        assertMerge(any(), anyExisting(), anyExisting());
+    }
+
+    @Test
+    public void mergeAnyAndExactly() {
+        assertMerge(any(), exactly(3), exactly(3));
+    }
+
+    @Test
+    public void mergeAnyAndNotCreated() {
+        assertMerge(any(), notCreated(), notCreated());
+    }
+
+    // Any existing
+
+    @Test
+    public void mergeAnyExistingAndAnyExisting() {
+        assertMerge(anyExisting(), anyExisting(), anyExisting());
+    }
+
+    @Test
+    public void mergeAnyExistingAndNull() {
+        assertMerge(anyExisting(), null, anyExisting());
+    }
+
+    @Test
+    public void mergeAnyExistingAndExactly() {
+        assertMerge(anyExisting(), exactly(3), exactly(3));
+    }
+
+    @Test
+    public void mergeAnyExistingAndNotCreated() {
+        assertMergeFail(anyExisting(), notCreated());
+    }
+
+    // Exactly
+
+    @Test
+    public void mergeExactlyAndEqualExactly() {
+        assertMerge(exactly(3), exactly(3), exactly(3));
+    }
+
+    @Test
+    public void mergeExactlyAndNull() {
+        assertMerge(exactly(3), null, exactly(3));
+    }
+
+    @Test
+    public void mergeExactlyAndDifferentExactly() {
+        assertMergeFail(exactly(3), exactly(4));
+    }
+
+    @Test
+    public void mergeExactlyAndNotCreated() {
+        assertMergeFail(exactly(3), notCreated());
+    }
+
+    // Not created
+
+    @Test
+    public void mergeNotCreatedAndNotCreated() {
+        assertMerge(notCreated(), notCreated(), notCreated());
+    }
+
+    @Test
+    public void mergeNotCreatedAndNull() {
+        assertMerge(notCreated(), null, notCreated());
+    }
+
+    private void assertMerge(
+            final ExpectedVersion first,
+            final ExpectedVersion second,
+            final ExpectedVersion expected) {
+        assertEqual(first + " merged with " + second, expected, merge(first, second));
+        assertEqual(second + " merged with " + first, expected, merge(second, first));
+    }
+
+    private void assertMergeFail(final ExpectedVersion first, final ExpectedVersion second) {
+        assertMergeFailOneDirection(first, second);
+        assertMergeFailOneDirection(second, first);
+    }
+
+    private void assertEqual(
+            final String msg,
+            final ExpectedVersion actual,
+            final ExpectedVersion expected) {
+        assertEquals(
+                "Version: " + msg,
+                expected.getExpectedVersion(),
+                actual.getExpectedVersion());
+        assertEquals("Type: " + msg, expected.getType(), actual.getType());
+    }
+
+    private void assertMergeFailOneDirection(
+            final ExpectedVersion first,
+            final ExpectedVersion second) {
+        try {
+            merge(first, second);
+            fail("Expected failure for merging " + first + " with " + second);
+        } catch (RuntimeException ex) {
+            // Success
+        }
+    }
+}


### PR DESCRIPTION
The functionality was previously unintentionally asymmetric. Merging
in one direction didn't necessarily result in the same result as merging
in the other.

This has now been avoided by always comparing in a certain order. The
order is given by the enums' ordinal number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elder-oss/sourcerer/14)
<!-- Reviewable:end -->
