### PR TITLE
Fix for CommandUtils.executeSynchronously not waiting for expected version

### DIFF
--- a/sourcerer-crud/src/main/java/org/elder/sourcerer/crud/CommandUtils.java
+++ b/sourcerer-crud/src/main/java/org/elder/sourcerer/crud/CommandUtils.java
@@ -160,14 +160,8 @@ public final class CommandUtils {
             return commandResponse;
         }
 
-        int expectedVersion;
-        if (commandResponse.getPreviousVersion() != null) {
-            expectedVersion = commandResponse.getPreviousVersion() + 1;
-            logger.debug("Looking for version {} based on previous", expectedVersion);
-        } else if (commandResponse.getNewVersion() != null) {
-            expectedVersion = commandResponse.getNewVersion();
-            logger.debug("Looking for version {} based on new", expectedVersion);
-        } else {
+        Integer expectedVersion = commandResponse.getNewVersion();
+        if (expectedVersion == null) {
             throw new IllegalArgumentException("Command was not no-op but returned no version!");
         }
 


### PR DESCRIPTION
Was using previous version before falling back to new version. We should
never need to use previous version anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elder-oss/sourcerer/18)
<!-- Reviewable:end -->
