### PR TITLE
Do not treat 0 events as empty stream

### DIFF
--- a/sourcerer-core/src/main/java/org/elder/sourcerer/DefaultAggregateRepository.java
+++ b/sourcerer-core/src/main/java/org/elder/sourcerer/DefaultAggregateRepository.java
@@ -127,7 +127,7 @@ public class DefaultAggregateRepository<TState, TEvent>
                         currentStreamPosition,
                         maxEventsPerRead);
 
-                if (readResult == null || readResult.getEvents().isEmpty()) {
+                if (readResult == null) {
                     // Not found, return empty wrapper as per contract
                     return DefaultImmutableAggregate.createNew(
                             projection,

--- a/sourcerer-core/src/test/java/org/elder/sourcerer/DefaultAggregateRepositoryTest.java
+++ b/sourcerer-core/src/test/java/org/elder/sourcerer/DefaultAggregateRepositoryTest.java
@@ -45,14 +45,6 @@ public class DefaultAggregateRepositoryTest {
         returnsAggregateWithEmptyStateOn(null);
     }
 
-    @Test
-    public void readReturnsEmptyOnEmptyStream() throws Exception {
-        returnsAggregateWithEmptyStateOn(
-                new EventReadResult(
-                        ImmutableList.of(),
-                        0, 10, 11, false));
-    }
-
     private void returnsAggregateWithEmptyStateOn(
             final EventReadResult readEventsResult) {
         when(eventRepository.read(any(), anyInt(), anyInt())).thenReturn(readEventsResult);


### PR DESCRIPTION
We should be seeing a null result if the stream is completely empty.

The new grpc client doesn't know when we reach the end of the stream. This will be caught on the next call when it receives no events, but it would previously treat this as "stream not found".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elder-oss/sourcerer/32)
<!-- Reviewable:end -->
