### PR TITLE
Fix issue with NoClassDefFoundError being silently dropped

### DIFF
--- a/sourcerer-eventstore-grpc/src/main/java/org/elder/sourcerer/eventstoredb/EventStoreGrpcEventRepository.java
+++ b/sourcerer-eventstore-grpc/src/main/java/org/elder/sourcerer/eventstoredb/EventStoreGrpcEventRepository.java
@@ -542,7 +542,7 @@ public class EventStoreGrpcEventRepository<T> implements EventRepository<T> {
             logger.debug("Incoming message in {}: {}", name, event);
             try {
                 emitter.next(EventSubscriptionUpdate.ofEvent(fromEsEvent(event)));
-            } catch (final Exception ex) {
+            } catch (final Exception | LinkageError ex) {
                 final RecordedEvent recordedEvent = event.getEvent();
                 final String eventType = recordedEvent == null ? null
                         : recordedEvent.getEventType();


### PR DESCRIPTION
When parsing the event, also catch `LinkageError`s.

This so we can catch errors like `NoClassDefFoundError`. If we don't catch these, then the subscription gets cancelled with only:
```
Subscription X was cancelled
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elder-oss/sourcerer/41)
<!-- Reviewable:end -->
